### PR TITLE
feat: add `GET /expeditions/weekly-rewards` endpoint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,8 +15,11 @@
       "files": ["*-test.ts", "*.spec.ts"],
       "rules": {
         "@typescript-eslint/ban-ts-comment": 0,
-        "no-unused-expressions": 0
+        "no-unused-expressions": 0,
+        "@typescript-eslint/no-explicit-any": 0
       }
     }
-  ]
+  ],
+  "ignorePatterns": ["**/generated/*/**"]
 }
+

--- a/src/modules/expeditions/controllers/types.ts
+++ b/src/modules/expeditions/controllers/types.ts
@@ -1,0 +1,26 @@
+import { APIGeneralResponse } from 'src/modules/shared/interfaces/response.interface';
+
+export interface IGetDailyVisitsRequest extends Request {
+  query: {
+    address: string;
+  };
+}
+
+export interface IAddDailyVisitsRequest extends Request {
+  payload: {
+    address: string;
+    signature: string;
+  };
+}
+
+export type IGetWeeklyRewardsRequest = IGetDailyVisitsRequest;
+export type IClaimWeeklyRewardsRequest = IAddDailyVisitsRequest;
+
+export type IGetDailyVisitsResponse = APIGeneralResponse<{
+  address: string;
+  allVisits: number;
+  lastVisit: Date | number;
+}>;
+
+export type IAddDailyVisitsResponse = IGetDailyVisitsResponse;
+

--- a/src/modules/expeditions/generated/graphql/queries.ts
+++ b/src/modules/expeditions/generated/graphql/queries.ts
@@ -4912,7 +4912,6 @@ export type GetLiquidityPositionDepositsBetweenTimestampAAndTimestampBQuery = { 
 
 export type GetLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampBQueryVariables = Exact<{
   address: Scalars['Bytes'];
-  minAmountUSD: Scalars['BigDecimal'];
   timestampA: Scalars['BigInt'];
   timestampB: Scalars['BigInt'];
 }>;
@@ -4933,7 +4932,7 @@ export const GetLiquidityPositionDepositsBetweenTimestampAAndTimestampBDocument 
 }
     `;
 export const GetLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampBDocument = gql`
-    query getLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampB($address: Bytes!, $minAmountUSD: BigDecimal!, $timestampA: BigInt!, $timestampB: BigInt!) {
+    query getLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampB($address: Bytes!, $timestampA: BigInt!, $timestampB: BigInt!) {
   liquidityMiningCampaignDeposits: deposits(
     where: {user: $address, timestamp_gte: $timestampA, timestamp_lte: $timestampB}
   ) {

--- a/src/modules/expeditions/graphql/queries.ts
+++ b/src/modules/expeditions/graphql/queries.ts
@@ -25,7 +25,6 @@ export const getLiquidityPositionDepositsBetweenTimestampAAndTimestampB = gql`
 export const getLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampB = gql`
   query getLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampB(
     $address: Bytes!
-    $minAmountUSD: BigDecimal!
     $timestampA: BigInt!
     $timestampB: BigInt!
   ) {

--- a/src/modules/expeditions/services/MultichainSubgraph.service.ts
+++ b/src/modules/expeditions/services/MultichainSubgraph.service.ts
@@ -8,6 +8,11 @@ export interface GetLiquidityPositionDepositsBetweenTimestampAAndTimestampBParam
   timestampB: number;
 }
 
+export type GetLiquidityStakingPositionBetweenTimestampAAndTimestampBParams = Omit<
+  GetLiquidityPositionDepositsBetweenTimestampAAndTimestampBParams,
+  'minAmountUSD'
+>;
+
 enum ChainId {
   MAINNET = 1,
   GNOSIS_CHAIN = 100,
@@ -68,6 +73,37 @@ export class MultichainSubgraphService {
 
         // Filter out results that are not within the time range
         return mints;
+      })
+    );
+
+    return resultsPerSubgraph.flat();
+  }
+
+  async getLiquidityStakingPositionBetweenTimestampAAndTimestampB({
+    address,
+    timestampA,
+    timestampB,
+  }: GetLiquidityStakingPositionBetweenTimestampAAndTimestampBParams) {
+    // Prepare the GraphQL client
+    const resultsPerSubgraph = await Promise.all(
+      Object.values(this.subgraphsSDKs).map(async subgraphSDK => {
+        // Bound results to this week
+        const {
+          liquidityMiningCampaignDeposits,
+          singleSidedStakingCampaignDeposits,
+        } = await subgraphSDK.getLiquidityMiningCampaignDepositsBetweenTimestampAAndTimestampB(
+          {
+            address,
+            timestampA,
+            timestampB,
+          }
+        );
+
+        // Filter out results that are not within the time range
+        return [
+          liquidityMiningCampaignDeposits,
+          singleSidedStakingCampaignDeposits,
+        ];
       })
     );
 

--- a/src/modules/expeditions/services/WeeklyFragments.service.ts
+++ b/src/modules/expeditions/services/WeeklyFragments.service.ts
@@ -7,7 +7,7 @@ import { CurrentWeekInformation } from '../utils/week';
 import type { MultichainSubgraphService } from './MultichainSubgraph.service';
 import type { WeeklyFragmentModel } from '../models/WeeklyFragment.model';
 
-interface WeeklyFragmentRewards {
+export interface WeeklyFragmentRewards {
   claimableFragments: number;
   claimedFragments: number;
   totalAmountUSD: number;

--- a/src/modules/routes/index.ts
+++ b/src/modules/routes/index.ts
@@ -6,6 +6,7 @@ import {
   addDailyVisitsController,
   getDailyVisitsController,
   getWeeklyLiquidityPositionDeposits,
+  getWeeklyRewardsFragmentsState,
 } from '../expeditions';
 
 /**
@@ -71,15 +72,36 @@ async function register(server: Server) {
 
   server.route({
     method: 'GET',
-    path: '/expeditions/weekly-liquidity',
+    path: '/expeditions/weekly-rewards',
     options: {
-      description: `Get an address's weekly liquidity`,
+      description: `Get an address's weekly rewards state for given address`,
       validate: {
         query: {
           address,
         },
       },
-      tags: ['api', 'expeditions', 'weekly liquidity'],
+      tags: [
+        'api',
+        'expeditions',
+        'weekly liquidity',
+        'weekly rewards',
+        'weekly rewards fragments',
+      ],
+    },
+    handler: getWeeklyRewardsFragmentsState,
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/expeditions/weekly-liquidity',
+    options: {
+      description: `Get an address's weekly liquidity rewards state for given address`,
+      validate: {
+        query: {
+          address,
+        },
+      },
+      tags: ['api', 'expeditions', 'weekly liquidity', 'weekly rewards'],
     },
     handler: getWeeklyLiquidityPositionDeposits,
   });


### PR DESCRIPTION
# Summary

- Fixes some queries with invalid variables
- Cleans up the types a bit
- Adds missing `getLiquidityStakingPositionBetweenTimestampAAndTimestampB`
- Registers `GET /expeditions/weekly-rewards` route and controller