### PR TITLE
Fix: enable claiming on more or equal to 50$

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,7 @@ services:
     ports:
       - 8081:8081
     environment:
-      ME_CONFIG_MONGODB_URL: mongodb://swapr:swapr@localhost:27017
+      ME_CONFIG_MONGODB_ADMINUSERNAME: swapr
+      ME_CONFIG_MONGODB_ADMINPASSWORD: swapr
+      ME_CONFIG_MONGODB_SERVER: mongo
+      ME_CONFIG_MONGODB_PORT: "27017"

--- a/src/modules/expeditions/services/weekly-fragments/WeeklyFragments.service.ts
+++ b/src/modules/expeditions/services/weekly-fragments/WeeklyFragments.service.ts
@@ -82,7 +82,7 @@ export class WeeklyFragmentService implements IWeeklyFragmentService {
     // Calculate claimable fragments for this week.
     // Add the base 50 fragments for this week
     // if the provided liquidity deposits are more than $50 USD
-    if (returnValue.totalAmountUSD > ADD_LIQUIDITY_MIN_USD_AMOUNT) {
+    if (returnValue.totalAmountUSD >= ADD_LIQUIDITY_MIN_USD_AMOUNT) {
       returnValue.claimableFragments = FRAGMENTS_PER_WEEK;
     }
 
@@ -142,7 +142,7 @@ export class WeeklyFragmentService implements IWeeklyFragmentService {
     // if the provided liquidity deposits are more than $50 USD
     if (
       weeklyFragmentDocument === null &&
-      returnValue.totalAmountUSD > ADD_LIQUIDITY_MIN_USD_AMOUNT
+      returnValue.totalAmountUSD >= ADD_LIQUIDITY_MIN_USD_AMOUNT
     ) {
       returnValue.claimableFragments = FRAGMENTS_PER_WEEK;
     }


### PR DESCRIPTION
I believe this is more in line with front-end flow. Without this change user has 50$ equivalent but still can't claim while instructions explicitly saying `at least 50$`.

Also I hope you don't mind more verbose `mongo-express` config in `docker-compose` - I couldn't connect with sole `URL`.